### PR TITLE
Add msys2 dependencies for Windows installation

### DIFF
--- a/ooxml_crypt.gemspec
+++ b/ooxml_crypt.gemspec
@@ -29,4 +29,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.2"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-compiler", "~> 1.1"
+
+  spec.metadata["msys2_mingw_dependencies"] = "openssl"
 end


### PR DESCRIPTION
In order to build this gem natively on Windows you need the `openssl` pacman package installed. Many users won't experience this because they would have installed the `openssl` gem already which gives them this package, however, this fix will allow users to install `ooxml_crypt` easily from scratch even if they didn't first install `openssl`.

FYI you can see this same line in the OpenSSL gemspec itself: https://github.com/ruby/openssl/blob/master/openssl.gemspec#L26